### PR TITLE
Refactor command and utility function names for consistency

### DIFF
--- a/cmd/gh-photos/main_test.go
+++ b/cmd/gh-photos/main_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewRootCommand(t *testing.T) {
-	cmd := NewRootCommand()
+	cmd := CreateRootCommand()
 
 	assert.Equal(t, "gh-photos", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -16,7 +16,7 @@ func TestNewRootCommand(t *testing.T) {
 }
 
 func TestNewSyncCommand(t *testing.T) {
-	cmd := NewSyncCommand()
+	cmd := CreateSyncCommand()
 
 	assert.Equal(t, "sync <backup-path> <remote>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -38,14 +38,14 @@ func TestNewSyncCommand(t *testing.T) {
 }
 
 func TestNewValidateCommand(t *testing.T) {
-	cmd := NewValidateCommand()
+	cmd := CreateValidateCommand()
 
 	assert.Equal(t, "validate [backup-path]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 }
 
 func TestNewListCommand(t *testing.T) {
-	cmd := NewListCommand()
+	cmd := CreateListCommand()
 
 	assert.Equal(t, "list <backup-path>", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
@@ -53,7 +53,7 @@ func TestNewListCommand(t *testing.T) {
 }
 
 func TestRootCommandLogLevel(t *testing.T) {
-	cmd := NewRootCommand()
+	cmd := CreateRootCommand()
 
 	// Check that log-level flag exists and has correct default
 	logLevelFlag := cmd.PersistentFlags().Lookup("log-level")

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -98,8 +98,8 @@ type TrailManager struct {
 	trail      *Trail
 }
 
-// NewTrailManager creates a new audit trail manager
-func NewTrailManager(cliVersion string) (*TrailManager, error) {
+// CreateTrailManager creates a new audit trail manager
+func CreateTrailManager(cliVersion string) (*TrailManager, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user home directory: %w", err)

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNewTrailManager(t *testing.T) {
-	tm, err := NewTrailManager("test-version")
+	tm, err := CreateTrailManager("test-version")
 	if err != nil {
 		t.Fatalf("Failed to create trail manager: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestNewTrailManager(t *testing.T) {
 }
 
 func TestSetDeviceInfo(t *testing.T) {
-	tm, err := NewTrailManager("test-version")
+	tm, err := CreateTrailManager("test-version")
 	if err != nil {
 		t.Fatalf("Failed to create trail manager: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestSetDeviceInfo(t *testing.T) {
 }
 
 func TestSetInvocation(t *testing.T) {
-	tm, err := NewTrailManager("test-version")
+	tm, err := CreateTrailManager("test-version")
 	if err != nil {
 		t.Fatalf("Failed to create trail manager: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestSetInvocation(t *testing.T) {
 }
 
 func TestAddAsset(t *testing.T) {
-	tm, err := NewTrailManager("test-version")
+	tm, err := CreateTrailManager("test-version")
 	if err != nil {
 		t.Fatalf("Failed to create trail manager: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestFinalize(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Override the trail directory for testing
-	tm, err := NewTrailManager("test-version")
+	tm, err := CreateTrailManager("test-version")
 	if err != nil {
 		t.Fatalf("Failed to create trail manager: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestLoadManifest(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	// Create and finalize a trail
-	tm, err := NewTrailManager("test-version")
+	tm, err := CreateTrailManager("test-version")
 	if err != nil {
 		t.Fatalf("Failed to create trail manager: %v", err)
 	}

--- a/internal/backup/extractor.go
+++ b/internal/backup/extractor.go
@@ -44,8 +44,8 @@ type Extractor struct {
 	summary  ExtractSummary
 }
 
-// NewExtractor creates a new backup extractor
-func NewExtractor(config ExtractConfig) (*Extractor, error) {
+// CreateExtractor creates a new backup extractor
+func CreateExtractor(config ExtractConfig) (*Extractor, error) {
 	// Validate backup path
 	if err := validateBackupDirectory(config.BackupPath); err != nil {
 		return nil, fmt.Errorf("invalid backup directory: %w", err)

--- a/internal/backup/extractor_test.go
+++ b/internal/backup/extractor_test.go
@@ -184,7 +184,7 @@ func TestNewExtractor(t *testing.T) {
 			defer os.RemoveAll(tempDir)
 
 			config := tt.setupFunc(tempDir)
-			extractor, err := NewExtractor(config)
+			extractor, err := CreateExtractor(config)
 
 			if tt.shouldError {
 				assert.Error(t, err)
@@ -246,6 +246,6 @@ func TestValidateManifestSchema(t *testing.T) {
 		Logger:     logger,
 	}
 
-	_, err = NewExtractor(config)
+	_, err = CreateExtractor(config)
 	assert.Error(t, err) // Should fail because no valid backup exists
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -81,8 +81,8 @@ type Generator struct {
 	config       Config
 }
 
-// NewGenerator creates a new manifest generator
-func NewGenerator(backupPath, remoteTarget string, config Config) *Generator {
+// CreateGenerator creates a new manifest generator
+func CreateGenerator(backupPath, remoteTarget string, config Config) *Generator {
 	return &Generator{
 		backupPath:   backupPath,
 		remoteTarget: remoteTarget,

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -16,7 +16,7 @@ func TestGenerator_CreateManifest(t *testing.T) {
 		Parallel:               4,
 	}
 
-	generator := NewGenerator("/test/backup", "gdrive:Photos", config)
+	generator := CreateGenerator("/test/backup", "gdrive:Photos", config)
 
 	// Create test assets
 	now := time.Now()

--- a/internal/photos/database.go
+++ b/internal/photos/database.go
@@ -20,8 +20,8 @@ type Database struct {
 	logger *logger.Logger
 }
 
-// NewDatabase creates a new Photos database connection
-func NewDatabase(dbPath string, logger *logger.Logger) (*Database, error) {
+// CreateDatabase creates a new Photos database connection
+func CreateDatabase(dbPath string, logger *logger.Logger) (*Database, error) {
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database %s: %w", dbPath, err)

--- a/internal/rclone/client_visibility_test.go
+++ b/internal/rclone/client_visibility_test.go
@@ -43,7 +43,7 @@ func TestBuildRemotePathConsistency(t *testing.T) {
 				Level:  logger.LevelInfo,
 			}
 			l := logger.New(config)
-			client := NewClient(tt.remote, 1, false, false, false, l, "info")
+			client := CreateClient(tt.remote, 1, false, false, false, l, "info")
 			result := client.buildRemotePath(tt.targetPath)
 			if result != tt.expected {
 				t.Errorf("buildRemotePath() = %v, want %v", result, tt.expected)
@@ -68,7 +68,7 @@ func TestFindExtractionMetadataFile(t *testing.T) {
 		Level:  logger.LevelInfo,
 	}
 	l := logger.New(config)
-	client := NewClient("test-remote", 1, false, false, false, l, "info")
+	client := CreateClient("test-remote", 1, false, false, false, l, "info")
 
 	// Test with no backup path set
 	result := client.findExtractionMetadataFile()
@@ -101,7 +101,7 @@ func TestMetadataUploadDryRun(t *testing.T) {
 	l := logger.New(config)
 
 	// Create client in dry run mode
-	client := NewClient("test-remote:", 1, false, true, false, l, "debug")
+	client := CreateClient("test-remote:", 1, false, true, false, l, "debug")
 
 	// Test dry run - should skip upload
 	err := client.testRemoteWriteCapabilityStartup()

--- a/internal/utils/paths.go
+++ b/internal/utils/paths.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"path/filepath"
+)
+
+// BackupPaths holds commonly used backup-related path construction utilities
+type BackupPaths struct {
+	backupPath string
+}
+
+// CreateBackupPaths creates a new BackupPaths instance
+func CreateBackupPaths(backupPath string) *BackupPaths {
+	return &BackupPaths{
+		backupPath: backupPath,
+	}
+}
+
+// ExtractionMetadata returns the path to the extraction metadata file
+func (bp *BackupPaths) ExtractionMetadata() string {
+	return filepath.Join(bp.backupPath, "extraction-metadata.json")
+}
+
+// ManifestPlist returns the path to the Manifest.plist file
+func (bp *BackupPaths) ManifestPlist() string {
+	return filepath.Join(bp.backupPath, "Manifest.plist")
+}
+
+// ManifestDB returns the path to the Manifest.db file
+func (bp *BackupPaths) ManifestDB() string {
+	return filepath.Join(bp.backupPath, "Manifest.db")
+}
+
+// MediaDCIM returns the path to the Media/DCIM directory for a given media domain
+func (bp *BackupPaths) MediaDCIM(mediaDomain string) string {
+	return filepath.Join(bp.backupPath, mediaDomain, "Media", "DCIM")
+}
+
+// DCIM returns the path to the DCIM directory for a given media domain
+func (bp *BackupPaths) DCIM(mediaDomain string) string {
+	return filepath.Join(bp.backupPath, mediaDomain, "DCIM")
+}
+
+// MediaPhotoData returns the path to the Media/PhotoData directory for a given media domain
+func (bp *BackupPaths) MediaPhotoData(mediaDomain string) string {
+	return filepath.Join(bp.backupPath, mediaDomain, "Media", "PhotoData")
+}
+
+// MediaDCIMFile returns the path to a specific file in the Media/DCIM directory
+func (bp *BackupPaths) MediaDCIMFile(mediaDomain, filename string) string {
+	return filepath.Join(bp.backupPath, mediaDomain, "Media", "DCIM", filename)
+}
+
+// MediaFile returns the path to a specific file in the Media directory
+func (bp *BackupPaths) MediaFile(mediaDomain, filename string) string {
+	return filepath.Join(bp.backupPath, mediaDomain, "Media", filename)
+}
+
+// DomainFile returns the path to a specific file in a media domain directory
+func (bp *BackupPaths) DomainFile(mediaDomain, filename string) string {
+	return filepath.Join(bp.backupPath, mediaDomain, filename)
+}
+
+// BackupSubdir returns the path to the Backup subdirectory
+func (bp *BackupPaths) BackupSubdir() string {
+	return filepath.Join(bp.backupPath, "Backup")
+}
+
+// RelativePath constructs a path relative to the backup path
+func (bp *BackupPaths) RelativePath(relativePath string) string {
+	return filepath.Join(bp.backupPath, relativePath)
+}

--- a/internal/utils/paths_test.go
+++ b/internal/utils/paths_test.go
@@ -1,0 +1,132 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackupPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   func(*BackupPaths) string
+		expected string
+	}{
+		{
+			name:     "ExtractionMetadata",
+			method:   (*BackupPaths).ExtractionMetadata,
+			expected: filepath.Join("/test/backup", "extraction-metadata.json"),
+		},
+		{
+			name:     "ManifestPlist",
+			method:   (*BackupPaths).ManifestPlist,
+			expected: filepath.Join("/test/backup", "Manifest.plist"),
+		},
+		{
+			name:     "ManifestDB",
+			method:   (*BackupPaths).ManifestDB,
+			expected: filepath.Join("/test/backup", "Manifest.db"),
+		},
+		{
+			name:     "BackupSubdir",
+			method:   (*BackupPaths).BackupSubdir,
+			expected: filepath.Join("/test/backup", "Backup"),
+		},
+	}
+
+	bp := CreateBackupPaths("/test/backup")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.method(bp)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBackupPathsWithDomain(t *testing.T) {
+	bp := CreateBackupPaths("/test/backup")
+	mediaDomain := "CameraRollDomain"
+
+	tests := []struct {
+		name     string
+		method   func(*BackupPaths, string) string
+		expected string
+	}{
+		{
+			name:     "MediaDCIM",
+			method:   (*BackupPaths).MediaDCIM,
+			expected: filepath.Join("/test/backup", "CameraRollDomain", "Media", "DCIM"),
+		},
+		{
+			name:     "DCIM",
+			method:   (*BackupPaths).DCIM,
+			expected: filepath.Join("/test/backup", "CameraRollDomain", "DCIM"),
+		},
+		{
+			name:     "MediaPhotoData",
+			method:   (*BackupPaths).MediaPhotoData,
+			expected: filepath.Join("/test/backup", "CameraRollDomain", "Media", "PhotoData"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.method(bp, mediaDomain)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBackupPathsWithDomainAndFile(t *testing.T) {
+	bp := CreateBackupPaths("/test/backup")
+	mediaDomain := "CameraRollDomain"
+	filename := "IMG_001.HEIC"
+
+	tests := []struct {
+		name     string
+		method   func(*BackupPaths, string, string) string
+		expected string
+	}{
+		{
+			name:     "MediaDCIMFile",
+			method:   (*BackupPaths).MediaDCIMFile,
+			expected: filepath.Join("/test/backup", "CameraRollDomain", "Media", "DCIM", "IMG_001.HEIC"),
+		},
+		{
+			name:     "MediaFile",
+			method:   (*BackupPaths).MediaFile,
+			expected: filepath.Join("/test/backup", "CameraRollDomain", "Media", "IMG_001.HEIC"),
+		},
+		{
+			name:     "DomainFile",
+			method:   (*BackupPaths).DomainFile,
+			expected: filepath.Join("/test/backup", "CameraRollDomain", "IMG_001.HEIC"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.method(bp, mediaDomain, filename)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRelativePath(t *testing.T) {
+	bp := CreateBackupPaths("/test/backup")
+
+	result := bp.RelativePath("some/relative/path")
+	expected := filepath.Join("/test/backup", "some/relative/path")
+
+	assert.Equal(t, expected, result)
+}
+
+func TestNewBackupPaths(t *testing.T) {
+	backupPath := "/test/backup"
+	bp := CreateBackupPaths(backupPath)
+
+	assert.NotNil(t, bp)
+	assert.Equal(t, backupPath, bp.backupPath)
+}

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,0 +1,16 @@
+package utils
+
+import "strings"
+
+// NormalizeString trims whitespace and converts to lowercase
+// This is a common pattern used throughout the codebase for normalizing user input
+func NormalizeString(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// ValidateStringInSet checks if a normalized string is in the provided valid set
+// Returns the normalized string and a boolean indicating if it's valid
+func ValidateStringInSet(input string, validSet map[string]bool) (string, bool) {
+	normalized := NormalizeString(input)
+	return normalized, validSet[normalized]
+}

--- a/internal/utils/strings_test.go
+++ b/internal/utils/strings_test.go
@@ -1,0 +1,108 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "lowercase input",
+			input:    "debug",
+			expected: "debug",
+		},
+		{
+			name:     "uppercase input",
+			input:    "DEBUG",
+			expected: "debug",
+		},
+		{
+			name:     "mixed case input",
+			input:    "Info",
+			expected: "info",
+		},
+		{
+			name:     "input with whitespace",
+			input:    "  warn  ",
+			expected: "warn",
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NormalizeString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestValidateStringInSet(t *testing.T) {
+	validLogLevels := map[string]bool{
+		"debug": true,
+		"info":  true,
+		"warn":  true,
+		"error": true,
+	}
+
+	tests := []struct {
+		name        string
+		input       string
+		expectedStr string
+		expectedOk  bool
+	}{
+		{
+			name:        "valid lowercase",
+			input:       "debug",
+			expectedStr: "debug",
+			expectedOk:  true,
+		},
+		{
+			name:        "valid uppercase",
+			input:       "DEBUG",
+			expectedStr: "debug",
+			expectedOk:  true,
+		},
+		{
+			name:        "valid with whitespace",
+			input:       "  info  ",
+			expectedStr: "info",
+			expectedOk:  true,
+		},
+		{
+			name:        "invalid value",
+			input:       "invalid",
+			expectedStr: "invalid",
+			expectedOk:  false,
+		},
+		{
+			name:        "empty input",
+			input:       "",
+			expectedStr: "",
+			expectedOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			str, ok := ValidateStringInSet(tt.input, validLogLevels)
+			assert.Equal(t, tt.expectedStr, str)
+			assert.Equal(t, tt.expectedOk, ok)
+		})
+	}
+}


### PR DESCRIPTION
- Updated command creation functions from New* to Create* for better clarity and consistency across the codebase.
- Refactored the audit trail manager, backup extractor, backup parser, and manifest generator to use the new naming convention.
- Introduced a new utils package with path-related utilities to simplify path management throughout the code.
- Enhanced the rclone client to support batch timeouts for improved upload management.
- Added unit tests for new utility functions and ensured existing tests reflect the updated function names.